### PR TITLE
fix: CTS400 temperature addresses corrected

### DIFF
--- a/src/genvexnabto/models/cts400.py
+++ b/src/genvexnabto/models/cts400.py
@@ -6,10 +6,10 @@ class GenvexNabtoCTS400(GenvexNabtoBaseModel):
         super().__init__()
 
         self._datapoints = {
-            GenvexNabtoDatapointKey.TEMP_SUPPLY: GenvexNabtoDatapoint(obj=0, address=30, divider=10, offset=0),
+            GenvexNabtoDatapointKey.TEMP_SUPPLY: GenvexNabtoDatapoint(obj=0, address=28, divider=10, offset=0),
             GenvexNabtoDatapointKey.TEMP_OUTSIDE: GenvexNabtoDatapoint(obj=0, address=27, divider=10, offset=0),
-            GenvexNabtoDatapointKey.TEMP_EXHAUST: GenvexNabtoDatapoint(obj=0, address=29, divider=10, offset=0),
-            GenvexNabtoDatapointKey.TEMP_EXTRACT: GenvexNabtoDatapoint(obj=0, address=28, divider=10, offset=0),
+            GenvexNabtoDatapointKey.TEMP_EXHAUST: GenvexNabtoDatapoint(obj=0, address=30, divider=10, offset=0),
+            GenvexNabtoDatapointKey.TEMP_EXTRACT: GenvexNabtoDatapoint(obj=0, address=29, divider=10, offset=0),
             GenvexNabtoDatapointKey.HUMIDITY: GenvexNabtoDatapoint(obj=0, address=31, divider=10, offset=0),
             GenvexNabtoDatapointKey.DUTYCYCLE_SUPPLY: GenvexNabtoDatapoint(obj=0, address=25, divider=10, offset=0),
             GenvexNabtoDatapointKey.DUTYCYCLE_EXTRACT: GenvexNabtoDatapoint(obj=0, address=24, divider=10, offset=0),


### PR DESCRIPTION
This is a fix suggestion for the issue reported in the genvexconnect library here:

[Explanation on temperature/fan directions](https://github.com/superrob/genvexconnect/issues/7)


The addresses have been tested, and now match the addresses in the other CTS400 libraries, such as https://github.com/nic6911/ESP32_Modbus_Module/blob/main/esphome_example_code/Nilan_cts400.yaml