### PR TITLE
feat: CTS400 add alarm flag

### DIFF
--- a/src/genvexnabto/models/basemodel.py
+++ b/src/genvexnabto/models/basemodel.py
@@ -33,6 +33,7 @@ class GenvexNabtoDatapointKey:
     ALARM_CTS602NO1 = "alarm_cts602no1"
     ALARM_CTS602NO2 = "alarm_cts602no2"
     ALARM_CTS602NO3 = "alarm_cts602no3"
+    ALARM_ACTIVE = "alarm_active"
 
 class GenvexNabtoSetpointKey:
     FAN_SPEED = "fan_speed"

--- a/src/genvexnabto/models/cts400.py
+++ b/src/genvexnabto/models/cts400.py
@@ -18,7 +18,8 @@ class GenvexNabtoCTS400(GenvexNabtoBaseModel):
             GenvexNabtoDatapointKey.CO2_LEVEL: GenvexNabtoDatapoint(obj=0, address=47, divider=1, offset=0),
             GenvexNabtoDatapointKey.FILTER_DAYS_LEFT: GenvexNabtoDatapoint(obj=0, address=110, divider=1, offset=0),
             GenvexNabtoDatapointKey.DEFROST_ACTIVE: GenvexNabtoDatapoint(obj=0, address=91, divider=1, offset=0),
-            GenvexNabtoDatapointKey.DEFORST_TIMESINCELAST: GenvexNabtoDatapoint(obj=0, address=89, divider=1, offset=0)               
+            GenvexNabtoDatapointKey.DEFORST_TIMESINCELAST: GenvexNabtoDatapoint(obj=0, address=89, divider=1, offset=0),    
+            GenvexNabtoDatapointKey.ALARM_ACTIVE: GenvexNabtoDatapoint(obj=0, address=50, divider=1, offset=0)                   
         }
 
         self._setpoints = {
@@ -48,7 +49,8 @@ class GenvexNabtoCTS400(GenvexNabtoBaseModel):
             GenvexNabtoDatapointKey.CO2_LEVEL,
             GenvexNabtoDatapointKey.FILTER_DAYS_LEFT,
             GenvexNabtoDatapointKey.DEFROST_ACTIVE,
-            GenvexNabtoDatapointKey.DEFORST_TIMESINCELAST
+            GenvexNabtoDatapointKey.DEFORST_TIMESINCELAST,
+            GenvexNabtoDatapointKey.ALARM_ACTIVE
         ]
 
         self._defaultSetpointRequest = [


### PR DESCRIPTION
The CTS400 unit has an alarm flag indicating if the system has issues.

The address matches other solutions supporting the "Alarm active" flag.
https://github.com/nic6911/ESP32_Modbus_Module/blob/main/esphome_example_code/Nilan_cts400.yaml

_I havent had the time to look into getting the list of alarms to identify the errorcode, but i managed to implement the flag indicating if there is an alarm active or not._