### PR TITLE
CTS400 - Added ON/OFF switch

### DIFF
--- a/src/genvexnabto/models/basemodel.py
+++ b/src/genvexnabto/models/basemodel.py
@@ -68,6 +68,7 @@ class GenvexNabtoSetpointKey:
     COOLING_ENABLE = "cooling_enable"
     COOLING_TEMPERATURE = "cooling_temperature"
     COOLING_OFFSET = "cooling_offset"
+    VENTILATION_ENABLE = "ventilation_enable"
 
 
 class GenvexNabtoDatapoint(TypedDict):

--- a/src/genvexnabto/models/cts400.py
+++ b/src/genvexnabto/models/cts400.py
@@ -35,7 +35,8 @@ class GenvexNabtoCTS400(GenvexNabtoBaseModel):
             GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL1: GenvexNabtoSetpoint(read_obj=0, read_address=63, write_obj=0, write_address=63, divider=10, offset=0, min=200, max=1000, step=1),
             GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL2: GenvexNabtoSetpoint(read_obj=0, read_address=64, write_obj=0, write_address=64, divider=10, offset=0, min=200, max=1000, step=1),
             GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL3: GenvexNabtoSetpoint(read_obj=0, read_address=65, write_obj=0, write_address=65, divider=10, offset=0, min=200, max=1000, step=1),
-            GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL4: GenvexNabtoSetpoint(read_obj=0, read_address=66, write_obj=0, write_address=66, divider=10, offset=0, min=200, max=1000, step=1)
+            GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL4: GenvexNabtoSetpoint(read_obj=0, read_address=66, write_obj=0, write_address=66, divider=10, offset=0, min=200, max=1000, step=1),
+            GenvexNabtoSetpointKey.VENTILATION_ENABLE: GenvexNabtoSetpoint(read_obj=0, read_address=70, write_obj=0, write_address=70, divider=1, offset=0, min=0, max=1, step=1)
         }
 
         self._defaultDatapointRequest = [
@@ -67,7 +68,8 @@ class GenvexNabtoCTS400(GenvexNabtoBaseModel):
             GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL1,
             GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL2,
             GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL3,
-            GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL4
+            GenvexNabtoSetpointKey.EXTRACT_AIR_LEVEL4,
+            GenvexNabtoSetpointKey.VENTILATION_ENABLE
         ]
 
     def getModelName(self):


### PR DESCRIPTION
The CTS400 unit does not support setting fan speed to step 0, but needs to set the on/off setting via a separate address.

I was not sure of the naming for the variables, but thought VENTILATION_ENABLE might be universal enough to be reused.
If you think the power switch is CTS400 specific, sorry for the naming.